### PR TITLE
Add fallback function to support running commands on different platforms

### DIFF
--- a/mcpuniverse/mcp/client.py
+++ b/mcpuniverse/mcp/client.py
@@ -73,11 +73,21 @@ class MCPClient(metaclass=AutodocABCMeta):
         Note:
             This method sets up the connection and initializes the client session.
         """
-        command = (
-            shutil.which(config.stdio.command)
-            if config.stdio.command in ["npx", "docker", "python", "python3"]
-            else config.stdio.command
-        )
+        def _resolve_command(command: str) -> str:
+            """Resolve command with platform-aware fallbacks."""
+            if command in ["npx", "docker", "python", "python3"]:
+                resolved = shutil.which(command)
+                # Fallback: python3 -> python (for Windows)
+                if resolved is None and command == "python3":
+                    resolved = shutil.which("python")
+                # Fallback: python -> python3 (for some Unix systems)       
+                if resolved is None and command == "python":
+                    resolved = shutil.which("python3")
+                return resolved
+            return command
+
+        command = _resolve_command(config.stdio.command)
+
         if command is None or command == "":
             raise ValueError("The command must be a valid string")
 


### PR DESCRIPTION
Making one config of `command: python3` (or vice versa) work on various platforms - Unix (`python3` / `python`) and Windows (`python`).