### PR TITLE
Add Salesforce Gateway Support and Smart Config Updates for MCP+ 

### DIFF
--- a/mcpuniverse/extensions/mcpplus/tools/proxy_server.py
+++ b/mcpuniverse/extensions/mcpplus/tools/proxy_server.py
@@ -176,14 +176,28 @@ class ProxyServer:
         # Resolve post-processing LLM if provided
         if self._config.llm:
             llm_manager = ModelManager()
-            # Expand env vars in api_key (e.g., "$OPENAI_API_KEY" -> actual value)
+            # Expand env vars in config (e.g., "$OPENAI_API_KEY" -> actual value)
             llm_config = self._config.llm.copy()
             if "config" in llm_config and isinstance(llm_config["config"], dict):
                 llm_config["config"] = llm_config["config"].copy()
+
+                # Expand api_key
                 api_key = llm_config["config"].get("api_key", "")
                 if isinstance(api_key, str) and api_key.startswith("$"):
                     env_var = api_key[1:]  # Remove leading $
-                    llm_config["config"]["api_key"] = os.environ.get(env_var, "")
+                    expanded_key = os.environ.get(env_var, "")
+                    llm_config["config"]["api_key"] = expanded_key
+                    self._logger.debug(f"Expanded ${env_var} for api_key (length: {len(expanded_key)})")
+
+                # Expand base_url (needed for gateway providers)
+                base_url = llm_config["config"].get("base_url", "")
+                if isinstance(base_url, str) and base_url.startswith("$"):
+                    env_var = base_url[1:]  # Remove leading $
+                    expanded_url = os.environ.get(env_var, "")
+                    llm_config["config"]["base_url"] = expanded_url
+                    self._logger.debug(f"Expanded ${env_var} for base_url: {expanded_url}")
+
+                self._logger.debug(f"Final LLM config - provider: {llm_config['name']}, base_url: {llm_config['config'].get('base_url', 'NOT SET')}")
             llm = llm_manager.build_model(**llm_config)
             llm.set_context(Context(env=dict(os.environ)))
             self._mcp_manager.set_llm(llm)
@@ -481,9 +495,15 @@ class ProxyServer:
                         await response_stream.aclose()
                         await response_stream_reader.aclose()
 
-                    # Parse raw response
-                    raw_result = response_or_error.result
-                    if isinstance(raw_result, dict) and 'resources' in raw_result:
+                    # Parse raw response - check if it's an error first
+                    if hasattr(response_or_error, 'error'):
+                        # This is a JSONRPCError
+                        self._logger.warning("Upstream returned error for resources/list: %s", response_or_error.error)
+                        raw_result = None
+                    else:
+                        raw_result = response_or_error.result
+
+                    if raw_result and isinstance(raw_result, dict) and 'resources' in raw_result:
                         for res_dict in raw_result['resources']:
                             uri = res_dict.get('uri', '')
                             # If URI doesn't have a scheme, add "mcpplus-proxy://" prefix

--- a/mcpuniverse/extensions/mcpplus/tools/proxy_server.py
+++ b/mcpuniverse/extensions/mcpplus/tools/proxy_server.py
@@ -187,7 +187,7 @@ class ProxyServer:
                     env_var = api_key[1:]  # Remove leading $
                     expanded_key = os.environ.get(env_var, "")
                     llm_config["config"]["api_key"] = expanded_key
-                    self._logger.debug(f"Expanded ${env_var} for api_key (length: {len(expanded_key)})")
+                    self._logger.debug("Expanded $%s for api_key (length: %d)", env_var, len(expanded_key))
 
                 # Expand base_url (needed for gateway providers)
                 base_url = llm_config["config"].get("base_url", "")
@@ -195,9 +195,10 @@ class ProxyServer:
                     env_var = base_url[1:]  # Remove leading $
                     expanded_url = os.environ.get(env_var, "")
                     llm_config["config"]["base_url"] = expanded_url
-                    self._logger.debug(f"Expanded ${env_var} for base_url: {expanded_url}")
+                    self._logger.debug("Expanded $%s for base_url: %s", env_var, expanded_url)
 
-                self._logger.debug(f"Final LLM config - provider: {llm_config['name']}, base_url: {llm_config['config'].get('base_url', 'NOT SET')}")
+                self._logger.debug("Final LLM config - provider: %s, base_url: %s",
+                                   llm_config['name'], llm_config['config'].get('base_url', 'NOT SET'))
             llm = llm_manager.build_model(**llm_config)
             llm.set_context(Context(env=dict(os.environ)))
             self._mcp_manager.set_llm(llm)

--- a/mcpuniverse/extensions/mcpplus/tools/wrap_mcp_config.py
+++ b/mcpuniverse/extensions/mcpplus/tools/wrap_mcp_config.py
@@ -291,18 +291,24 @@ def _find_config_differences(old_config: Dict[str, Any], new_config: Dict[str, A
     new_wrapper = new_config.get("wrapper", {})
 
     if old_wrapper.get("token_threshold") != new_wrapper.get("token_threshold"):
-        differences.append(f"threshold: {old_wrapper.get('token_threshold', '?')} → {new_wrapper.get('token_threshold', '?')}")
+        old_val = old_wrapper.get('token_threshold', '?')
+        new_val = new_wrapper.get('token_threshold', '?')
+        differences.append(f"threshold: {old_val} → {new_val}")
 
     if old_wrapper.get("max_iterations") != new_wrapper.get("max_iterations"):
-        differences.append(f"max_iterations: {old_wrapper.get('max_iterations', '?')} → {new_wrapper.get('max_iterations', '?')}")
+        old_val = old_wrapper.get('max_iterations', '?')
+        new_val = new_wrapper.get('max_iterations', '?')
+        differences.append(f"max_iterations: {old_val} → {new_val}")
 
     if old_wrapper.get("llm_timeout") != new_wrapper.get("llm_timeout"):
-        differences.append(f"llm_timeout: {old_wrapper.get('llm_timeout', '?')} → {new_wrapper.get('llm_timeout', '?')}")
+        old_val = old_wrapper.get('llm_timeout', '?')
+        new_val = new_wrapper.get('llm_timeout', '?')
+        differences.append(f"llm_timeout: {old_val} → {new_val}")
 
     return differences
 
 
-def _should_update_plus_server(
+def _should_update_plus_server(  # pylint: disable=too-many-return-statements
     base_name: str,
     existing_servers: Dict[str, Dict[str, Any]],
     config_dir: Path,
@@ -354,10 +360,9 @@ def _should_update_plus_server(
 
         if added_keys:
             return True, f"env vars added ({', '.join(sorted(added_keys)[:2])})"
-        elif removed_keys:
+        if removed_keys:
             return True, f"env vars removed ({', '.join(sorted(removed_keys)[:2])})"
-        else:
-            return True, "env var values changed"
+        return True, "env var values changed"
 
     # Load existing proxy config file
     proxy_config_path = config_dir / f"proxy_{base_name}.json"
@@ -366,7 +371,8 @@ def _should_update_plus_server(
 
     try:
         existing_proxy = _load_json(proxy_config_path)
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
+        # Catch any JSON parsing or file reading errors
         return True, "proxy config corrupted"
 
     # Normalize both configs for comparison (only relevant fields)
@@ -521,7 +527,7 @@ def _prepare_wrap_changes(
 
     # Use the already-built configs (built above during comparison phase)
     # This avoids rebuilding configs twice and ensures what we compared is what we write
-    for name in servers_to_wrap.keys():
+    for name in servers_to_wrap:
         plus_name = f"{name}-plus"
 
         # Get the pre-built proxy config and MCP entry (already built during comparison)

--- a/mcpuniverse/extensions/mcpplus/tools/wrap_mcp_config.py
+++ b/mcpuniverse/extensions/mcpplus/tools/wrap_mcp_config.py
@@ -44,6 +44,32 @@ def _get_config_dir() -> Path:
     return Path.home() / ".mcpplus" / "configs"
 
 
+def _get_gateway_llm_config_fields(llm_provider: str) -> Dict[str, str]:
+    """
+    Get additional config fields needed for gateway LLM providers.
+
+    Returns env var references (e.g., "$ENG_AI_MODEL_GW_URL") which will be
+    expanded by the proxy server at runtime.
+
+    Args:
+        llm_provider: The LLM provider name
+
+    Returns:
+        Dict of additional config fields with $VAR references
+    """
+    extra_config = {}
+
+    # Salesforce LLM Express Gateway
+    if llm_provider == "sf_llm_express_gateway":
+        extra_config["base_url"] = "$ENG_AI_MODEL_GW_URL"
+
+    # Salesforce Research Gateway
+    elif llm_provider == "sf_research_gateway":
+        extra_config["base_url"] = "$RESEARCH_GATEWAY_URL"
+
+    return extra_config
+
+
 def _build_proxy_config(
     upstream: str,
     server_name: str,
@@ -59,6 +85,16 @@ def _build_proxy_config(
     headers: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Build a proxy wrapper config for the given upstream server."""
+    # Build base LLM config
+    llm_config = {
+        "model_name": llm_model,
+        "api_key": f"${llm_api_key_env}",
+    }
+
+    # Add gateway-specific config fields (e.g., base_url)
+    gateway_config = _get_gateway_llm_config_fields(llm_provider)
+    llm_config.update(gateway_config)
+
     config = {
         "upstream_server": upstream,
         "server_name": server_name,
@@ -70,10 +106,7 @@ def _build_proxy_config(
         "upstream_env": env or {},
         "llm": {
             "name": llm_provider,
-            "config": {
-                "model_name": llm_model,
-                "api_key": f"${llm_api_key_env}",
-            },
+            "config": llm_config,
         },
         "wrapper": {
             "enabled": True,
@@ -92,17 +125,76 @@ def _build_proxy_config(
     return config
 
 
+def _get_gateway_env_vars(llm_provider: str) -> Dict[str, str]:
+    """
+    Get required environment variables for gateway LLM providers.
+
+    Args:
+        llm_provider: The LLM provider name
+
+    Returns:
+        Dict of environment variable names and their values
+    """
+    env_vars = {}
+
+    # Salesforce LLM Express Gateway
+    if llm_provider == "sf_llm_express_gateway":
+        if os.getenv("ENG_AI_MODEL_GW_URL"):
+            env_vars["ENG_AI_MODEL_GW_URL"] = os.getenv("ENG_AI_MODEL_GW_URL")
+        if os.getenv("ENG_AI_MODEL_GW_KEY"):
+            env_vars["ENG_AI_MODEL_GW_KEY"] = os.getenv("ENG_AI_MODEL_GW_KEY")
+
+    # Salesforce Research Gateway
+    elif llm_provider == "sf_research_gateway":
+        if os.getenv("RESEARCH_GATEWAY_URL"):
+            env_vars["RESEARCH_GATEWAY_URL"] = os.getenv("RESEARCH_GATEWAY_URL")
+        if os.getenv("SALESFORCE_GATEWAY_KEY"):
+            env_vars["SALESFORCE_GATEWAY_KEY"] = os.getenv("SALESFORCE_GATEWAY_KEY")
+
+    # Legacy Claude Gateway
+    elif llm_provider == "claude_gateway":
+        if os.getenv("SALESFORCE_GATEWAY_KEY"):
+            env_vars["SALESFORCE_GATEWAY_KEY"] = os.getenv("SALESFORCE_GATEWAY_KEY")
+
+    return env_vars
+
+
 def _build_mcp_entry(
     server_name: str,  # pylint: disable=unused-argument
     config_path: Path,
     llm_api_key_env: str = "OPENAI_API_KEY",
     llm_api_key_value: Optional[str] = None,
+    llm_provider: str = "openai",
 ) -> Dict[str, Any]:
-    """Build an MCP server entry for mcp.json config (Cursor, Claude Desktop, etc.)."""
+    """
+    Build an MCP server entry for mcp.json config (Cursor, Claude Desktop, etc.).
+
+    Uses sys.executable to get the absolute path to the current Python interpreter.
+    This ensures Cursor/Claude Desktop can find the right Python with mcpuniverse installed,
+    even if they don't load your shell environment.
+
+    Args:
+        server_name: Name of the server
+        config_path: Path to the proxy config file
+        llm_api_key_env: Environment variable name for the API key
+        llm_api_key_value: Optional actual API key value
+        llm_provider: The LLM provider being used
+
+    Returns:
+        MCP server configuration dict
+    """
     # Use actual key value if provided, otherwise fall back to env var reference
     env_value = llm_api_key_value if llm_api_key_value else f"${llm_api_key_env}"
+
+    # Build env vars dict
+    env_dict = {llm_api_key_env: env_value}
+
+    # Add gateway-specific environment variables
+    gateway_env_vars = _get_gateway_env_vars(llm_provider)
+    env_dict.update(gateway_env_vars)
+
     return {
-        "command": "python3",
+        "command": sys.executable,  # Absolute path to current Python interpreter
         "args": [
             "-m",
             "mcpuniverse.extensions.mcpplus.tools.proxy_server",
@@ -111,9 +203,7 @@ def _build_mcp_entry(
             "--transport",
             "stdio",
         ],
-        "env": {
-            llm_api_key_env: env_value,
-        },
+        "env": env_dict,
     }
 
 
@@ -146,6 +236,160 @@ def _prompt_confirmation(message: str = "Proceed?") -> bool:
         print("Please enter 'y' or 'n'")
 
 
+def _normalize_config_for_comparison(config: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Normalize config by removing fields that shouldn't trigger updates.
+
+    Args:
+        config: The config dict to normalize
+
+    Returns:
+        Normalized config with only comparison-relevant fields
+    """
+    # Create a deep copy and remove fields that don't matter for comparison
+    normalized = {
+        "llm": config.get("llm", {}),
+        "wrapper": config.get("wrapper", {}),
+    }
+    return normalized
+
+
+def _find_config_differences(old_config: Dict[str, Any], new_config: Dict[str, Any]) -> List[str]:
+    """
+    Find specific differences between two configs.
+
+    Args:
+        old_config: Existing config
+        new_config: New config to compare
+
+    Returns:
+        List of human-readable differences
+    """
+    differences = []
+
+    # Compare LLM settings
+    old_llm = old_config.get("llm", {})
+    new_llm = new_config.get("llm", {})
+
+    if old_llm.get("name") != new_llm.get("name"):
+        differences.append(f"provider: {old_llm.get('name', '?')} → {new_llm.get('name', '?')}")
+
+    old_llm_config = old_llm.get("config", {})
+    new_llm_config = new_llm.get("config", {})
+
+    if old_llm_config.get("model_name") != new_llm_config.get("model_name"):
+        differences.append(f"model: {old_llm_config.get('model_name', '?')} → {new_llm_config.get('model_name', '?')}")
+
+    if old_llm_config.get("api_key") != new_llm_config.get("api_key"):
+        old_key = old_llm_config.get("api_key", "?")
+        new_key = new_llm_config.get("api_key", "?")
+        # Only show env var name, not actual key
+        differences.append(f"api_key_env: {old_key} → {new_key}")
+
+    # Compare wrapper settings
+    old_wrapper = old_config.get("wrapper", {})
+    new_wrapper = new_config.get("wrapper", {})
+
+    if old_wrapper.get("token_threshold") != new_wrapper.get("token_threshold"):
+        differences.append(f"threshold: {old_wrapper.get('token_threshold', '?')} → {new_wrapper.get('token_threshold', '?')}")
+
+    if old_wrapper.get("max_iterations") != new_wrapper.get("max_iterations"):
+        differences.append(f"max_iterations: {old_wrapper.get('max_iterations', '?')} → {new_wrapper.get('max_iterations', '?')}")
+
+    if old_wrapper.get("llm_timeout") != new_wrapper.get("llm_timeout"):
+        differences.append(f"llm_timeout: {old_wrapper.get('llm_timeout', '?')} → {new_wrapper.get('llm_timeout', '?')}")
+
+    return differences
+
+
+def _should_update_plus_server(
+    base_name: str,
+    existing_servers: Dict[str, Dict[str, Any]],
+    config_dir: Path,
+    new_proxy_config: Dict[str, Any],
+    new_mcp_entry: Dict[str, Any],
+) -> Tuple[bool, Optional[str]]:
+    """
+    Check if a -plus server needs updating by comparing proxy config and mcp.json entry.
+
+    Args:
+        base_name: Name of the base server (without -plus suffix)
+        existing_servers: All servers from mcp.json
+        config_dir: Directory containing proxy configs
+        new_proxy_config: The new proxy config that would be written
+        new_mcp_entry: The new mcp.json entry that would be written
+
+    Returns:
+        Tuple of (should_update, reason):
+        - should_update: True if config differs or doesn't exist
+        - reason: Human-readable reason for update (or None if no update needed)
+    """
+    plus_name = f"{base_name}-plus"
+
+    # Check if -plus entry exists in mcp.json
+    if plus_name not in existing_servers:
+        return True, "new"
+
+    # Check if MCP entry changed (command, args, or env)
+    existing_mcp_entry = existing_servers[plus_name]
+
+    # Check command
+    if existing_mcp_entry.get("command") != new_mcp_entry.get("command"):
+        old_cmd = existing_mcp_entry.get("command", "?")
+        new_cmd = new_mcp_entry.get("command", "?")
+        # Show just the filename, not full path for readability
+        old_py = Path(old_cmd).name if old_cmd else "?"
+        new_py = Path(new_cmd).name if new_cmd else "?"
+        return True, f"python changed ({old_py} → {new_py})"
+
+    # Check env vars
+    old_env = existing_mcp_entry.get("env", {})
+    new_env = new_mcp_entry.get("env", {})
+    if old_env != new_env:
+        # Find what changed
+        old_keys = set(old_env.keys())
+        new_keys = set(new_env.keys())
+        added_keys = new_keys - old_keys
+        removed_keys = old_keys - new_keys
+
+        if added_keys:
+            return True, f"env vars added ({', '.join(sorted(added_keys)[:2])})"
+        elif removed_keys:
+            return True, f"env vars removed ({', '.join(sorted(removed_keys)[:2])})"
+        else:
+            return True, "env var values changed"
+
+    # Load existing proxy config file
+    proxy_config_path = config_dir / f"proxy_{base_name}.json"
+    if not proxy_config_path.exists():
+        return True, "proxy config missing"
+
+    try:
+        existing_proxy = _load_json(proxy_config_path)
+    except Exception:
+        return True, "proxy config corrupted"
+
+    # Normalize both configs for comparison (only relevant fields)
+    old_normalized = _normalize_config_for_comparison(existing_proxy)
+    new_normalized = _normalize_config_for_comparison(new_proxy_config)
+
+    # Deep comparison
+    if old_normalized == new_normalized:
+        return False, None
+
+    # Find specific differences for user-friendly message
+    differences = _find_config_differences(existing_proxy, new_proxy_config)
+
+    if differences:
+        reason = ", ".join(differences[:2])  # Show first 2 changes
+        if len(differences) > 2:
+            reason += f" (+{len(differences) - 2} more)"
+        return True, reason
+
+    # Generic fallback if we can't determine specific differences
+    return True, "config changed"
+
+
 def _prepare_wrap_changes(
     mcp_config_path: Path,
     servers: Optional[List[str]] = None,
@@ -153,16 +397,17 @@ def _prepare_wrap_changes(
     llm_model: str = "gpt-5-mini-2025-08-07",
     llm_api_key_env: str = "OPENAI_API_KEY",
     token_threshold: int = 2000,
-) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Tuple[Path, Dict[str, Any]]], Optional[str]]:
+) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Tuple[Path, Dict[str, Any]]], Optional[str], Dict[str, str]]:
     """
     Prepare the changes that will be made (without writing anything).
 
     Returns:
-        Tuple of (full_config, new_mcp_entries, proxy_configs, api_key_value)
+        Tuple of (full_config, new_mcp_entries, proxy_configs, api_key_value, update_reasons)
         - full_config: The full mcp.json config with new entries added
         - new_mcp_entries: Just the new server entries to be added
         - proxy_configs: Dict of {server_name: (config_path, config_data)}
         - api_key_value: The API key value from environment (or None)
+        - update_reasons: Dict of {base_server_name: reason_string} for tracking updates
     """
     config_dir = _get_config_dir()
     existing_servers = _parse_mcp_config(mcp_config_path)
@@ -180,13 +425,88 @@ def _prepare_wrap_changes(
         if missing:
             print(f"Servers not found in config: {missing}", file=sys.stderr)
             sys.exit(1)
-        servers_to_wrap = {k: v for k, v in existing_servers.items() if k in servers}
+        base_servers = {k: v for k, v in existing_servers.items() if k in servers}
     else:
-        # Skip servers that are already -plus versions
-        servers_to_wrap = {k: v for k, v in existing_servers.items() if not k.endswith("-plus")}
+        # Get base servers (exclude existing -plus versions from consideration)
+        base_servers = {k: v for k, v in existing_servers.items() if not k.endswith("-plus")}
+
+    # Build all proxy configs and MCP entries, then determine which need updating
+    all_proxy_configs = {}  # {base_name: proxy_config_dict}
+    all_mcp_entries = {}  # {base_name: mcp_entry_dict}
+    servers_to_wrap = {}
+    update_reasons = {}
+
+    for name, server_cfg in base_servers.items():
+        # Build the proxy config for this server
+        if "http_url" in server_cfg or "url" in server_cfg:
+            url = server_cfg.get("http_url") or server_cfg.get("url", "")
+            headers = server_cfg.get("headers", {})
+            if not url:
+                continue
+
+            proxy_config = _build_proxy_config(
+                upstream=name,
+                server_name=f"{name}-plus",
+                command=None,
+                args=None,
+                env=None,
+                llm_provider=llm_provider,
+                llm_model=llm_model,
+                llm_api_key_env=llm_api_key_env,
+                token_threshold=token_threshold,
+                transport="http",
+                upstream_url=url,
+                headers=headers if headers else None,
+            )
+        else:
+            command = server_cfg.get("command", "")
+            args = server_cfg.get("args", [])
+            env = server_cfg.get("env", {})
+            if not command:
+                continue
+
+            proxy_config = _build_proxy_config(
+                upstream=name,
+                server_name=f"{name}-plus",
+                command=command,
+                args=args,
+                env=env,
+                llm_provider=llm_provider,
+                llm_model=llm_model,
+                llm_api_key_env=llm_api_key_env,
+                token_threshold=token_threshold,
+                transport="stdio",
+            )
+
+        # Store the built configs
+        all_proxy_configs[name] = proxy_config
+
+        # Build the MCP entry to compare against existing
+        proxy_config_path = config_dir / f"proxy_{name}.json"
+        mcp_entry = _build_mcp_entry(
+            server_name=f"{name}-plus",
+            config_path=proxy_config_path,
+            llm_api_key_env=llm_api_key_env,
+            llm_api_key_value=api_key_value,
+            llm_provider=llm_provider,
+        )
+        all_mcp_entries[name] = mcp_entry
+
+        # Check if this server needs updating
+        should_update, reason = _should_update_plus_server(
+            base_name=name,
+            existing_servers=existing_servers,
+            config_dir=config_dir,
+            new_proxy_config=proxy_config,
+            new_mcp_entry=mcp_entry,
+        )
+
+        if should_update:
+            servers_to_wrap[name] = server_cfg
+            update_reasons[name] = reason
 
     if not servers_to_wrap:
-        print("No servers to wrap (all may already be wrapped)", file=sys.stderr)
+        print("No servers to wrap/update (all configurations are up-to-date)", file=sys.stderr)
         sys.exit(0)
 
     # Load full config to preserve structure
@@ -199,78 +519,24 @@ def _prepare_wrap_changes(
     new_entries = {}
     proxy_configs = {}
 
-    for name, server_cfg in servers_to_wrap.items():
+    # Use the already-built configs (built above during comparison phase)
+    # This avoids rebuilding configs twice and ensures what we compared is what we write
+    for name in servers_to_wrap.keys():
         plus_name = f"{name}-plus"
 
-        # Check transport type: http_url (HTTP), url (HTTP/SSE), or command (stdio)
-        if "http_url" in server_cfg or "url" in server_cfg:
-            # HTTP or SSE server
-            # Prefer http_url if explicitly provided, otherwise use url
-            url = server_cfg.get("http_url") or server_cfg.get("url", "")
-            headers = server_cfg.get("headers", {})
-
-            if not url:
-                continue
-
-            # Try HTTP first (modern servers typically support HTTP)
-            # The proxy/client will handle fallback to SSE if needed
-            transport = "http"
-
-            # Build proxy config for HTTP (with potential SSE fallback)
-            proxy_config = _build_proxy_config(
-                upstream=name,
-                server_name=plus_name,
-                command=None,  # No command for HTTP/SSE
-                args=None,
-                env=None,
-                llm_provider=llm_provider,
-                llm_model=llm_model,
-                llm_api_key_env=llm_api_key_env,
-                token_threshold=token_threshold,
-                transport=transport,
-                upstream_url=url,
-                headers=headers if headers else None,
-            )
-
-        else:
-            # stdio server
-            command = server_cfg.get("command", "")
-            args = server_cfg.get("args", [])
-            env = server_cfg.get("env", {})
-
-            if not command:
-                continue
-
-            # Build proxy config for stdio
-            proxy_config = _build_proxy_config(
-                upstream=name,
-                server_name=plus_name,
-                command=command,
-                args=args,
-                env=env,
-                llm_provider=llm_provider,
-                llm_model=llm_model,
-                llm_api_key_env=llm_api_key_env,
-                token_threshold=token_threshold,
-                transport="stdio",
-            )
-
+        # Get the pre-built proxy config and MCP entry (already built during comparison)
+        proxy_config = all_proxy_configs[name]
         proxy_config_path = config_dir / f"proxy_{name}.json"
         proxy_configs[plus_name] = (proxy_config_path, proxy_config)
 
-        # Build MCP entry
-        mcp_entry = _build_mcp_entry(
-            server_name=plus_name,
-            config_path=proxy_config_path,
-            llm_api_key_env=llm_api_key_env,
-            llm_api_key_value=api_key_value,
-        )
+        # Get the pre-built MCP entry (already has correct Python path from sys.executable)
+        mcp_entry = all_mcp_entries[name]
         new_entries[plus_name] = mcp_entry
 
     # Add new entries to config (in memory only)
     servers_section.update(new_entries)
 
-    return full_config, new_entries, proxy_configs, api_key_value
+    return full_config, new_entries, proxy_configs, api_key_value, update_reasons
 
 
 def wrap_servers(
@@ -302,7 +568,7 @@ def wrap_servers(
         The updated config dict
     """
     # Prepare all changes first (no writes yet)
-    full_config, new_entries, proxy_configs, api_key_value = _prepare_wrap_changes(
+    full_config, new_entries, proxy_configs, api_key_value, update_reasons = _prepare_wrap_changes(
         mcp_config_path=mcp_config_path,
         servers=servers,
         llm_provider=llm_provider,
@@ -322,6 +588,10 @@ def wrap_servers(
     print("MCP+ Wrapper Configuration Preview")
     print("=" * 60)
 
+    # Python interpreter info
+    print(f"\n[Python] Using: {sys.executable}")
+    print("         This Python will be used to run proxy servers.")
+
     # API key status
     if api_key_value:
         print(f"\n[API Key] Found {llm_api_key_env} in environment.")
@@ -330,13 +600,29 @@ def wrap_servers(
         print(f"\n[API Key] Warning: {llm_api_key_env} not found in environment.")
         print(f"          Will use ${llm_api_key_env} reference.")
 
-    # Show proxy configs that will be created
-    print(f"\n[Proxy Configs] Will create {len(proxy_configs)} file(s) in ~/.mcpplus/configs/:")
-    for _, (config_path, _) in proxy_configs.items():
-        print(f"  - {config_path}")
+    # Show proxy configs that will be created/updated
+    print(f"\n[Proxy Configs] Will create/update {len(proxy_configs)} file(s) in ~/.mcpplus/configs/:")
+    for server_name, (config_path, _) in proxy_configs.items():
+        base_name = server_name.replace("-plus", "")
+        reason = update_reasons.get(base_name, "unknown")
 
-    # Show entries that will be added to mcp.json
-    print(f"\n[MCP Config] Will add {len(new_entries)} server(s) to {output}:")
+        if reason == "new":
+            print(f"  ✨ {config_path.name} (new)")
+        else:
+            print(f"  🔄 {config_path.name} (update: {reason})")
+
+    # Show entries that will be added/updated in mcp.json
+    new_count = sum(1 for r in update_reasons.values() if r == "new")
+    update_count = len(update_reasons) - new_count
+
+    if new_count > 0 and update_count > 0:
+        action_desc = f"add {new_count} new and update {update_count} existing"
+    elif new_count > 0:
+        action_desc = f"add {new_count}"
+    else:
+        action_desc = f"update {update_count}"
+
+    print(f"\n[MCP Config] Will {action_desc} server(s) in {output}:")
     print("-" * 60)
     print(json.dumps(new_entries, indent=2))
     print("-" * 60)
@@ -364,15 +650,29 @@ def wrap_servers(
     print("\nApplying changes...")
 
     # Write proxy configs
-    for _, (config_path, proxy_config) in proxy_configs.items():
+    for server_name, (config_path, proxy_config) in proxy_configs.items():
         _write_json(config_path, proxy_config)
-        print(f"  Created: {config_path}")
+        base_name = server_name.replace("-plus", "")
+        reason = update_reasons.get(base_name, "unknown")
+
+        if reason == "new":
+            print(f"  ✨ Created: {config_path}")
+        else:
+            print(f"  🔄 Updated: {config_path}")
 
     # Write updated mcp.json
     _write_json(output, full_config)
     print(f"  Updated: {output}")
 
-    print(f"\nSuccess! Added {len(new_entries)} wrapped server(s).")
+    new_count = sum(1 for r in update_reasons.values() if r == "new")
+    update_count = len(update_reasons) - new_count
+
+    if new_count > 0 and update_count > 0:
+        print(f"\nSuccess! Created {new_count} and updated {update_count} wrapped server(s).")
+    elif new_count > 0:
+        print(f"\nSuccess! Created {new_count} wrapped server(s).")
+    else:
+        print(f"\nSuccess! Updated {update_count} wrapped server(s).")
     print("\nNext steps:")
     print("  1. Restart your MCP client (Cursor, Claude Desktop, etc.)")
     print("  2. Use the '-plus' servers (e.g., 'finance-plus' instead of 'finance')")

--- a/mcpuniverse/llm/__init__.py
+++ b/mcpuniverse/llm/__init__.py
@@ -14,6 +14,8 @@ from .local_llm import LocalLLMModel
 # Backward compatibility alias
 VLLMLocalModel = LocalLLMModel
 from .claude_wr import ClaudeWRModel
+from .sf_llm_express_gateway import SFLLMExpressGatewayModel
+from .sf_research_gateway import SFResearchGatewayModel
 # TITO (Token In Token Out) — vLLM engine, trajectory manager, agent wrapper
 from .tito import (
     AsyncVLLMEngine, AsyncVLLMBackend, VLLMEngineConfig,
@@ -35,6 +37,8 @@ __all__ = [
     "GeminiModel",
     "LocalLLMModel",
     "VLLMLocalModel",  # backward compat alias
+    "SFLLMExpressGatewayModel",
+    "SFResearchGatewayModel",
     # Direct vLLM engine (no HTTP serve)
     "AsyncVLLMEngine",
     "AsyncVLLMBackend",

--- a/mcpuniverse/llm/sf_llm_express_gateway.py
+++ b/mcpuniverse/llm/sf_llm_express_gateway.py
@@ -1,0 +1,186 @@
+"""
+Salesforce LLM Express Gateway Provider
+
+This provider routes requests through the Salesforce Engineering AI Model Gateway
+using an OpenAI-compatible API format. It supports any model available
+through the gateway (Claude, OpenAI, etc.).
+
+Configuration:
+    Both the gateway URL and API key must be set via environment variables
+    to maintain security and avoid exposing internal infrastructure in the codebase.
+
+    Required environment variables:
+        - ENG_AI_MODEL_GW_URL: Gateway endpoint URL (e.g., "https://your-gateway.example.com")
+        - ENG_AI_MODEL_GW_KEY: Your gateway API key
+
+    Example usage:
+        export ENG_AI_MODEL_GW_URL="https://your-gateway.example.com"
+        export ENG_AI_MODEL_GW_KEY="your-api-key"
+
+        # Then use in your code or with mcp-build-plus:
+        mcp-build-plus --mcp-config ~/.cursor/mcp.json \
+            --llm-provider sf_llm_express_gateway \
+            --llm-model gpt-5-mini \
+            --llm-api-key-env ENG_AI_MODEL_GW_KEY
+"""
+import os
+from typing import Dict, Union, Optional
+from mcpuniverse.common.context import Context
+from .openai import OpenAIModel, OpenAIConfig
+
+
+class SFLLMExpressGatewayConfig(OpenAIConfig):
+    """
+    Configuration for Salesforce LLM Express Gateway.
+
+    Both the gateway URL and API key should be set via environment variables
+    to avoid exposing internal infrastructure details in the codebase.
+
+    Required environment variables:
+        - ENG_AI_MODEL_GW_URL: The gateway endpoint URL (e.g., "https://your-gateway.example.com")
+        - ENG_AI_MODEL_GW_KEY: The gateway API key
+
+    Attributes:
+        base_url (str): The gateway endpoint URL from ENG_AI_MODEL_GW_URL environment variable.
+        model_name (str): The model to use. Defaults to "gpt-5-mini".
+        api_key (str): The gateway API key from ENG_AI_MODEL_GW_KEY environment variable.
+        temperature (float): Controls randomness in output generation. Defaults to 0.0.
+        top_p (float): Controls diversity of output generation. Defaults to 1.0.
+        max_completion_tokens (int): Maximum number of tokens to generate. Defaults to 10000.
+    """
+    base_url: str = os.getenv("ENG_AI_MODEL_GW_URL", "")
+    model_name: str = "gpt-5-mini"
+    api_key: str = os.getenv("ENG_AI_MODEL_GW_KEY", "")
+    temperature: float = 0.0
+    top_p: float = 1.0
+    max_completion_tokens: int = 10000
+
+
+class SFLLMExpressGatewayModel(OpenAIModel):
+    """
+    LLM provider for Salesforce LLM Express Gateway.
+
+    This class extends OpenAIModel since the gateway uses an OpenAI-compatible API.
+    It routes requests through the Salesforce Engineering AI Model Gateway, supporting
+    any model available on the gateway (Claude, OpenAI, etc.).
+
+    The gateway provides:
+    - Centralized billing and rate limiting
+    - Support for multiple model providers
+    - Enterprise-grade security and compliance
+
+    Attributes:
+        config_class: The configuration class.
+        alias: Short name "sf_llm_express_gateway".
+        env_vars: Required environment variables.
+    """
+    config_class = SFLLMExpressGatewayConfig
+    alias = "sf_llm_express_gateway"
+    env_vars = ["ENG_AI_MODEL_GW_URL", "ENG_AI_MODEL_GW_KEY"]
+
+    def __init__(self, config: Optional[Union[Dict, str]] = None):
+        """
+        Initialize the SFLLMExpressGatewayModel instance.
+
+        Args:
+            config: Configuration for the model. Can be a dictionary or a string.
+                If None, default configuration will be used.
+        """
+        super().__init__(config)
+        # Config is already loaded by parent OpenAIModel.__init__
+        # OpenAI client will be created automatically in _generate() using self.config
+
+    def _generate(self, messages, response_format=None, **kwargs):
+        """
+        Override parent _generate for gateway-specific behavior.
+
+        Key differences from parent:
+        1. Skips reasoning_effort parameter (LiteLLM proxy validates strictly)
+        2. Re-raises non-retryable errors instead of returning None
+
+        Args:
+            messages: List of message dictionaries with 'role' and 'content' keys.
+            response_format: Optional Pydantic model for structured output.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            Generated content or response object.
+
+        Raises:
+            Exception: Re-raises non-retryable errors for visibility.
+        """
+        from openai import OpenAI, RateLimitError, APIError, APITimeoutError
+        import time
+        import logging
+
+        max_retries = kwargs.get("max_retries", 5)
+        base_delay = kwargs.get("base_delay", 10.0)
+
+        for attempt in range(max_retries + 1):
+            try:
+                client = OpenAI(api_key=self.config.api_key, base_url=self.config.base_url)
+
+                # Don't add reasoning_effort for gateway models - the LiteLLM proxy
+                # has stricter parameter validation than direct OpenAI API
+
+                if response_format is None:
+                    params = {
+                        "messages": messages,
+                        "model": self.config.model_name,
+                        "temperature": self.config.temperature,
+                        "top_p": self.config.top_p,
+                        "max_completion_tokens": self.config.max_completion_tokens,
+                        "timeout": self.config.timeout,
+                    }
+                    if 'tools' in kwargs:
+                        params["parallel_tool_calls"] = self.config.parallel_tool_calls
+                    params.update(kwargs)
+                    chat = client.chat.completions.create(**params)
+                    if 'tools' in kwargs:
+                        return chat
+                    return chat.choices[0].message.content
+
+                params = {
+                    "messages": messages,
+                    "model": self.config.model_name,
+                    "temperature": self.config.temperature,
+                    "top_p": self.config.top_p,
+                    "max_completion_tokens": self.config.max_completion_tokens,
+                    "response_format": response_format,
+                }
+                if 'tools' in kwargs:
+                    params["parallel_tool_calls"] = self.config.parallel_tool_calls
+                params.update(kwargs)
+                chat = client.beta.chat.completions.parse(**params)
+                if 'tools' in kwargs:
+                    return chat
+                return chat.choices[0].message.parsed
+
+            except (RateLimitError, APIError, APITimeoutError) as e:
+                # These are retryable errors
+                if attempt == max_retries:
+                    logging.warning("All %d attempts failed. Last error: %s", max_retries + 1, e)
+                    return None
+
+                delay = base_delay * (2 ** attempt)
+                logging.info("Attempt %d failed with error: %s. Retrying in %.1f seconds...",
+                           attempt + 1, e, delay)
+                time.sleep(delay)
+
+            except Exception as e:
+                # Non-retryable errors - re-raise so they're visible
+                logging.error("Non-retryable error occurred: %s", e)
+                raise
+
+    def set_context(self, context: Context):
+        """
+        Set context, e.g., environment variables (URL and API keys).
+
+        Args:
+            context: The context containing environment variables.
+        """
+        super().set_context(context)
+        # Update config values from environment
+        self.config.api_key = context.env.get("ENG_AI_MODEL_GW_KEY", self.config.api_key)
+        self.config.base_url = context.env.get("ENG_AI_MODEL_GW_URL", self.config.base_url)
+        # No need to create client here - OpenAIModel._generate() creates it using these config values

--- a/mcpuniverse/llm/sf_llm_express_gateway.py
+++ b/mcpuniverse/llm/sf_llm_express_gateway.py
@@ -24,7 +24,11 @@ Configuration:
             --llm-api-key-env ENG_AI_MODEL_GW_KEY
 """
 import os
-from typing import Dict, Union, Optional
+import time
+import logging
+
+from openai import OpenAI, RateLimitError, APIError, APITimeoutError
+
 from mcpuniverse.common.context import Context
 from .openai import OpenAIModel, OpenAIConfig
 
@@ -78,18 +82,6 @@ class SFLLMExpressGatewayModel(OpenAIModel):
     alias = "sf_llm_express_gateway"
     env_vars = ["ENG_AI_MODEL_GW_URL", "ENG_AI_MODEL_GW_KEY"]
 
-    def __init__(self, config: Optional[Union[Dict, str]] = None):
-        """
-        Initialize the SFLLMExpressGatewayModel instance.
-
-        Args:
-            config: Configuration for the model. Can be a dictionary or a string.
-                If None, default configuration will be used.
-        """
-        super().__init__(config)
-        # Config is already loaded by parent OpenAIModel.__init__
-        # OpenAI client will be created automatically in _generate() using self.config
-
     def _generate(self, messages, response_format=None, **kwargs):
         """
         Override parent _generate for gateway-specific behavior.
@@ -109,10 +101,6 @@ class SFLLMExpressGatewayModel(OpenAIModel):
         Raises:
             Exception: Re-raises non-retryable errors for visibility.
         """
-        from openai import OpenAI, RateLimitError, APIError, APITimeoutError
-        import time
-        import logging
-
         max_retries = kwargs.get("max_retries", 5)
         base_delay = kwargs.get("base_delay", 10.0)
 

--- a/mcpuniverse/llm/sf_research_gateway.py
+++ b/mcpuniverse/llm/sf_research_gateway.py
@@ -31,9 +31,11 @@ import time
 import logging
 import json
 import uuid
-import requests
 from typing import Dict, Union, Optional, List, Type, Any
 from dataclasses import dataclass
+
+import requests
+from openai import OpenAI
 from pydantic import BaseModel as PydanticBaseModel
 
 from mcpuniverse.common.config import BaseConfig
@@ -137,7 +139,6 @@ class SFResearchGatewayModel(BaseLLM):
     def _get_openai_client(self):
         """Get or create OpenAI client for OpenAI models."""
         if self.client is None:
-            from openai import OpenAI
             openai_url = f"{self.config.base_url.rstrip('/')}/openai/process/v1/"
             self.client = OpenAI(
                 api_key="dummy",  # Required by OpenAI client but not used
@@ -168,13 +169,12 @@ class SFResearchGatewayModel(BaseLLM):
         # Route based on model type
         if self._is_claude_model(model_name):
             return self._generate_claude(messages, response_format, **kwargs)
-        elif self._is_openai_model(model_name):
+        if self._is_openai_model(model_name):
             return self._generate_openai(messages, response_format, **kwargs)
-        else:
-            raise ValueError(
-                f"Unsupported model type: {model_name}. "
-                f"Must be a Claude model (contains 'claude') or OpenAI model (contains 'gpt'/'openai')."
-            )
+        raise ValueError(
+            f"Unsupported model type: {model_name}. "
+            f"Must be a Claude model (contains 'claude') or OpenAI model (contains 'gpt'/'openai')."
+        )
 
     def _generate_openai(
             self,
@@ -310,7 +310,8 @@ class SFResearchGatewayModel(BaseLLM):
                            attempt + 1, e, delay)
                 time.sleep(delay)
 
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                # Catch any non-retryable errors (e.g., authentication, SSL, etc.)
                 logging.error("Non-retryable error occurred: %s", e)
                 return None
 

--- a/mcpuniverse/llm/sf_research_gateway.py
+++ b/mcpuniverse/llm/sf_research_gateway.py
@@ -1,0 +1,492 @@
+"""
+Salesforce Research Gateway Provider
+
+This provider routes requests through the Salesforce Research Gateway
+with support for multiple model types (Claude, OpenAI, etc.).
+
+The gateway uses different endpoints for different model families:
+- Claude models: /claude3/process (with Claude-native format)
+- OpenAI models: /openai/process/v1/ (with OpenAI-compatible format)
+
+Configuration:
+    Both the gateway URL and API key must be set via environment variables
+    to maintain security and avoid exposing internal infrastructure in the codebase.
+
+    Required environment variables:
+        - RESEARCH_GATEWAY_URL: Base gateway URL (e.g., "https://your-gateway.example.com")
+        - SALESFORCE_GATEWAY_KEY: Your gateway API key
+
+    Example usage:
+        export RESEARCH_GATEWAY_URL="https://your-gateway.example.com"
+        export SALESFORCE_GATEWAY_KEY="your-api-key"
+
+        # Then use in your code or with mcp-build-plus:
+        mcp-build-plus --mcp-config ~/.cursor/mcp.json \
+            --llm-provider sf_research_gateway \
+            --llm-model gpt-5-mini \
+            --llm-api-key-env SALESFORCE_GATEWAY_KEY
+"""
+import os
+import time
+import logging
+import json
+import uuid
+import requests
+from typing import Dict, Union, Optional, List, Type, Any
+from dataclasses import dataclass
+from pydantic import BaseModel as PydanticBaseModel
+
+from mcpuniverse.common.config import BaseConfig
+from mcpuniverse.common.logger import get_logger
+from mcpuniverse.common.context import Context
+from .base import BaseLLM
+
+
+# Claude model name mappings (for Research Gateway)
+CLAUDE_MODEL_MAP = {
+    "claude-sonnet-4": {
+        "model_name": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        "thinking_enabled": False
+    },
+    "claude-sonnet-4-thinking": {
+        "model_name": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        "thinking_enabled": True
+    },
+    "claude-opus-4": {
+        "model_name": "us.anthropic.claude-opus-4-20250514-v1:0",
+        "thinking_enabled": False
+    },
+    "claude-opus-4-thinking": {
+        "model_name": "us.anthropic.claude-opus-4-20250514-v1:0",
+        "thinking_enabled": True
+    }
+}
+
+
+@dataclass
+class SFResearchGatewayConfig(BaseConfig):
+    """
+    Configuration for Salesforce Research Gateway.
+
+    Both the gateway URL and API key should be set via environment variables
+    to avoid exposing internal infrastructure details in the codebase.
+
+    Required environment variables:
+        - RESEARCH_GATEWAY_URL: The base gateway URL (without endpoint path)
+        - SALESFORCE_GATEWAY_KEY: The gateway API key
+
+    Attributes:
+        base_url (str): The base gateway URL from RESEARCH_GATEWAY_URL environment variable.
+        model_name (str): The model to use. Defaults to "gpt-5-mini".
+        api_key (str): The gateway API key from SALESFORCE_GATEWAY_KEY environment variable.
+        temperature (float): Controls randomness in output generation. Defaults to 0.0.
+        top_p (float): Controls diversity of output generation. Defaults to 1.0.
+        max_completion_tokens (int): Maximum number of tokens to generate. Defaults to 10000.
+        thinking_budget_tokens (int): Token budget for Claude thinking mode. Defaults to 4000.
+    """
+    base_url: str = os.getenv("RESEARCH_GATEWAY_URL", "")
+    model_name: str = "gpt-5-mini"
+    api_key: str = os.getenv("SALESFORCE_GATEWAY_KEY", "")
+    temperature: float = 0.0
+    top_p: float = 1.0
+    max_completion_tokens: int = 10000
+    thinking_budget_tokens: int = 4000
+
+
+class SFResearchGatewayModel(BaseLLM):
+    """
+    LLM provider for Salesforce Research Gateway.
+
+    This class intelligently routes requests to the appropriate gateway endpoint
+    based on the model type:
+    - Claude models → /claude3/process with Claude-native format
+    - OpenAI models → /openai/process/v1/ with OpenAI format
+
+    Authentication uses custom X-Api-Key header for both endpoints.
+
+    Attributes:
+        config_class: The configuration class.
+        alias: Short name "sf_research_gateway".
+        env_vars: Required environment variables.
+    """
+    config_class = SFResearchGatewayConfig
+    alias = "sf_research_gateway"
+    env_vars = ["RESEARCH_GATEWAY_URL", "SALESFORCE_GATEWAY_KEY"]
+
+    def __init__(self, config: Optional[Union[Dict, str]] = None):
+        """
+        Initialize the SFResearchGatewayModel instance.
+
+        Args:
+            config: Configuration for the model. Can be a dictionary or a string.
+                If None, default configuration will be used.
+        """
+        super().__init__()
+        self.config = SFResearchGatewayModel.config_class.load(config)
+        self.logger = get_logger(self.__class__.__name__)
+        self.client = None  # Will be created on demand for OpenAI models
+
+    def _is_claude_model(self, model_name: str) -> bool:
+        """Check if the model is a Claude model."""
+        return "claude" in model_name.lower()
+
+    def _is_openai_model(self, model_name: str) -> bool:
+        """Check if the model is an OpenAI model."""
+        return "gpt" in model_name.lower() or "openai" in model_name.lower()
+
+    def _get_openai_client(self):
+        """Get or create OpenAI client for OpenAI models."""
+        if self.client is None:
+            from openai import OpenAI
+            openai_url = f"{self.config.base_url.rstrip('/')}/openai/process/v1/"
+            self.client = OpenAI(
+                api_key="dummy",  # Required by OpenAI client but not used
+                base_url=openai_url,
+                default_headers={"X-Api-Key": self.config.api_key}
+            )
+        return self.client
+
+    def _generate(
+            self,
+            messages: List[dict[str, str]],
+            response_format: Type[PydanticBaseModel] = None,
+            **kwargs
+    ):
+        """
+        Generate content using the appropriate gateway endpoint.
+
+        Args:
+            messages: A list of message dictionaries with 'role' and 'content' keys.
+            response_format: A Pydantic model for structured output (OpenAI only).
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            The generated content or response object.
+        """
+        model_name = self.config.model_name
+
+        # Route based on model type
+        if self._is_claude_model(model_name):
+            return self._generate_claude(messages, response_format, **kwargs)
+        elif self._is_openai_model(model_name):
+            return self._generate_openai(messages, response_format, **kwargs)
+        else:
+            raise ValueError(
+                f"Unsupported model type: {model_name}. "
+                f"Must be a Claude model (contains 'claude') or OpenAI model (contains 'gpt'/'openai')."
+            )
+
+    def _generate_openai(
+            self,
+            messages: List[dict[str, str]],
+            response_format: Type[PydanticBaseModel] = None,
+            **kwargs
+    ):
+        """Generate using OpenAI endpoint."""
+        client = self._get_openai_client()
+
+        # Build completion parameters
+        completion_params = {
+            "model": self.config.model_name,
+            "messages": messages,
+            "temperature": self.config.temperature,
+            "top_p": self.config.top_p,
+            "max_tokens": self.config.max_completion_tokens,
+        }
+
+        # Add response format if provided
+        if response_format:
+            completion_params["response_format"] = response_format
+
+        # Add tools if provided
+        if "tools" in kwargs:
+            completion_params["tools"] = kwargs["tools"]
+
+        # Add any other kwargs
+        for key in ["tool_choice", "parallel_tool_calls"]:
+            if key in kwargs:
+                completion_params[key] = kwargs[key]
+
+        response = client.chat.completions.create(**completion_params)
+
+        # Return based on whether tools were used
+        if "tools" in kwargs:
+            return response
+
+        return response.choices[0].message.content
+
+    def _generate_claude(
+            self,
+            messages: List[dict[str, str]],
+            response_format: Type[PydanticBaseModel] = None,
+            **kwargs
+    ):
+        """Generate using Claude endpoint (mirrors claude_gateway.py logic)."""
+        max_retries = kwargs.get("max_retries", 5)
+        base_delay = kwargs.get("base_delay", 10.0)
+
+        # Get Claude-specific model config
+        model_config = CLAUDE_MODEL_MAP.get(self.config.model_name, {
+            "model_name": self.config.model_name,
+            "thinking_enabled": False
+        })
+        claude_model_name = model_config["model_name"]
+        thinking_enabled = model_config["thinking_enabled"]
+
+        for attempt in range(max_retries + 1):
+            try:
+                headers = {
+                    'Content-Type': 'application/json',
+                    'X-Api-Key': self.config.api_key
+                }
+
+                system_messages, formatted_messages = [], []
+                formatted_messages = self._convert_openai_messages_to_claude(
+                    messages, system_messages
+                )
+                system_message = "\n".join(system_messages)
+
+                if response_format is None:
+                    data = {
+                        "prompts": formatted_messages,
+                        "model_id": claude_model_name,
+                        "stream": False,
+                        "temperature": self.config.temperature,
+                        "max_tokens": self.config.max_completion_tokens,
+                        "system": system_message,
+                        "top_p": self.config.top_p,
+                        "timeout": int(kwargs.get("timeout", 30))
+                    }
+
+                    # Handle thinking parameter
+                    if thinking_enabled:
+                        data["thinking"] = {
+                            "type": "enabled",
+                            "budget_tokens": kwargs.get("thinking_budget_tokens",
+                            self.config.thinking_budget_tokens)
+                        }
+
+                    # Handle tools if provided
+                    if 'tools' in kwargs:
+                        data['tools'] = self._convert_openai_tools_to_claude(kwargs['tools'])
+
+                    # Remove custom parameters from kwargs before updating data
+                    filtered_kwargs = {k: v for k, v in kwargs.items()
+                                     if k not in [
+                                        'thinking_enabled',
+                                        'thinking_budget_tokens',
+                                        'tools', 'max_retries',
+                                        'base_delay']}
+                    data.update(filtered_kwargs)
+
+                    claude_url = f"{self.config.base_url.rstrip('/')}/claude3/process"
+                    response = requests.post(
+                        claude_url,
+                        json=data,
+                        headers=headers,
+                        timeout=int(kwargs.get("timeout", 30))
+                    )
+
+                    response.raise_for_status()
+                    response_json = json.loads(response.text)
+
+                    # If tools are provided, return a response object
+                    if 'tools' in kwargs:
+                        return self._create_openai_style_response(response_json)
+
+                    # For backward compatibility, return just the text content
+                    return response_json['result'][0]['text']
+
+                raise NotImplementedError("Research gateway Claude endpoint does not support response_format!")
+
+            except (requests.exceptions.RequestException, requests.exceptions.Timeout,
+                    requests.exceptions.HTTPError) as e:
+                if attempt == max_retries:
+                    logging.warning("All %d attempts failed. Last error: %s", max_retries + 1, e)
+                    return None
+
+                delay = base_delay * (2 ** attempt)
+                logging.info("Attempt %d failed with error: %s. Retrying in %.1f seconds...",
+                           attempt + 1, e, delay)
+                time.sleep(delay)
+
+            except Exception as e:
+                logging.error("Non-retryable error occurred: %s", e)
+                return None
+
+    # Claude message conversion methods (from claude_gateway.py)
+    def _handle_system_message(self, message: dict, system_messages: List[str]):
+        """Handle system message by adding to system_messages list."""
+        system_messages.append(message["content"])
+
+    def _handle_user_message(self, message: dict) -> dict:
+        """Handle user message conversion."""
+        return {
+            "role": "user",
+            "content": message["content"]
+        }
+
+    def _handle_assistant_message_with_tools(self, message: dict) -> dict:
+        """Handle assistant message with tool calls."""
+        content_blocks = []
+
+        if message.get("content"):
+            content_blocks.append({
+                "type": "text",
+                "text": message["content"]
+            })
+
+        for tool_call in message["tool_calls"]:
+            if tool_call.get("type") == "function":
+                func = tool_call["function"]
+                arguments = func["arguments"]
+                if isinstance(arguments, str):
+                    try:
+                        arguments = json.loads(arguments)
+                    except json.JSONDecodeError:
+                        arguments = {}
+
+                content_blocks.append({
+                    "type": "tool_use",
+                    "id": tool_call["id"],
+                    "name": func["name"],
+                    "input": arguments
+                })
+
+        return {
+            "role": "assistant",
+            "content": content_blocks
+        }
+
+    def _handle_assistant_message(self, message: dict) -> dict:
+        """Handle regular assistant message."""
+        return {
+            "role": "assistant",
+            "content": message["content"]
+        }
+
+    def _handle_tool_message(self, message: dict) -> dict:
+        """Handle tool result message."""
+        return {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": message["tool_call_id"],
+                    "content": message["content"]
+                }
+            ]
+        }
+
+    def _convert_openai_messages_to_claude(
+            self,
+            messages: List[dict],
+            system_messages: List[str]
+        ) -> List[dict]:
+        """Convert OpenAI format messages to Claude format."""
+        claude_messages = []
+
+        for message in messages:
+            role = message.get("role")
+
+            if role == "system":
+                self._handle_system_message(message, system_messages)
+            elif role == "user":
+                claude_messages.append(self._handle_user_message(message))
+            elif role == "assistant":
+                if "tool_calls" in message and message["tool_calls"]:
+                    claude_messages.append(self._handle_assistant_message_with_tools(message))
+                else:
+                    claude_messages.append(self._handle_assistant_message(message))
+            elif role == "tool":
+                claude_messages.append(self._handle_tool_message(message))
+
+        return claude_messages
+
+    def _convert_openai_tools_to_claude(self, openai_tools: List[dict]) -> List[dict]:
+        """Convert OpenAI format tools to Claude format."""
+        claude_tools = []
+        for tool in openai_tools:
+            if tool.get("type") == "function" and "function" in tool:
+                func_def = tool["function"]
+                if "title" in func_def:
+                    del func_def["title"]
+                claude_tool = {
+                    "name": func_def["name"],
+                    "description": func_def.get("description", ""),
+                    "input_schema": func_def.get("parameters", {})
+                }
+                claude_tools.append(claude_tool)
+        return claude_tools
+
+    def _create_openai_style_response(self, response_json: dict):
+        """Create an OpenAI-style response object from Claude's response."""
+        @dataclass
+        class Choice:
+            """Choice class for OpenAI-style response"""
+            message: Any
+
+        @dataclass
+        class Message:
+            """Message class for OpenAI-style response"""
+            content: Optional[str] = None
+            tool_calls: Optional[List[Any]] = None
+
+        @dataclass
+        class Response:
+            """Response class for OpenAI-style response"""
+            choices: List[Choice]
+            model: str
+
+        result_blocks = response_json.get('result', [])
+        openai_tool_calls = []
+        text_content = ""
+
+        for block in result_blocks:
+            if isinstance(block, dict):
+                if block.get('type') == 'text':
+                    text_content += block.get('text', '')
+                elif block.get('type') == 'tool_use':
+                    tool_id = block.get('id', str(uuid.uuid4()))
+                    tool_name = block.get('name', '')
+                    tool_input = block.get('input', {})
+
+                    tool_call = {
+                        "id": tool_id,
+                        "type": "function",
+                        "function": {
+                            "name": tool_name,
+                            "arguments": (
+                                json.dumps(tool_input)
+                                if isinstance(tool_input, dict)
+                                else str(tool_input)
+                            )
+                        }
+                    }
+                    openai_tool_calls.append(tool_call)
+
+        content = text_content if text_content else None
+        tool_calls = openai_tool_calls if openai_tool_calls else None
+
+        message = Message(content=content, tool_calls=tool_calls)
+        choice = Choice(message)
+        response = Response(choices=[choice], model=self.config.model_name)
+        return response
+
+    def support_tool_call(self) -> bool:
+        """Return a flag indicating if the model supports function/tool call API."""
+        return True
+
+    def set_context(self, context: Context):
+        """
+        Set context, e.g., environment variables (URL and API keys).
+
+        Args:
+            context: The context containing environment variables.
+        """
+        super().set_context(context)
+        self.config.api_key = context.env.get("SALESFORCE_GATEWAY_KEY", self.config.api_key)
+        self.config.base_url = context.env.get("RESEARCH_GATEWAY_URL", self.config.base_url)
+
+        # Reset client to force recreation with new settings
+        self.client = None


### PR DESCRIPTION
Adds support for two internal Salesforce LLM gateways and improves the MCP+ wrapper to intelligently detect and update configuration changes.            

**New LLM Providers:**                  
  - sf_llm_express_gateway - Salesforce Engineering AI Model Gateway with OpenAI-compatible API
  - sf_research_gateway - Salesforce Research Gateway with intelligent routing (Claude → /claude3/process, OpenAI → /openai/process/v1/)                   
                                                                                                                                        
**Smart Config Updates:**               
  - wrap_mcp_config.py now detects configuration changes and updates existing -plus servers instead of skipping them                                       
  - Compares LLM settings (provider, model, base_url), wrapper settings (token_threshold, max_iterations), Python command, and environment variables       
  - Shows detailed diff of what changed when updating servers                

**Bug Fixes:**                          
  - Fixed JSONRPCError handling in proxy_server.py (attempted to access .result on error objects)                                                          
  - Added environment variable expansion for base_url (previously only expanded api_key)                                                                   
  - Use sys.executable for Python command instead of hardcoded "python3" to respect virtualenvs                                                            
  - Removed reasoning_effort parameter for gateway models (LiteLLM proxy validates strictly)                                                               
  - Improved error visibility by re-raising non-retryable errors instead of swallowing them                                                                

**Usage**                               

  export ENG_AI_MODEL_GW_URL="https://your-gateway.example.com"              
  export ENG_AI_MODEL_GW_KEY="your-api-key"                                  

  mcp-build-plus --mcp-config ~/.cursor/mcp.json \                           
      --llm-provider sf_llm_express_gateway \                                
      --llm-model gpt-5-mini \        
      --llm-api-key-env ENG_AI_MODEL_GW_KEY  