### PR TITLE
feat: add jcodemunch-mcp code intelligence benchmark (10 tasks)

### DIFF
--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence.yaml
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence.yaml
@@ -1,0 +1,42 @@
+kind: llm
+spec:
+  name: llm-1
+  type: openai
+  config:
+    model_name: gpt-4.1
+
+---
+kind: agent
+spec:
+  name: ReAct-agent
+  type: react
+  config:
+    llm: llm-1
+    instruction: >
+      You are a code intelligence agent. Use jcodemunch tools to explore and
+      analyze codebases efficiently. Always index a repository before querying
+      it. Prefer targeted symbol search, outlines, and ranked context retrieval
+      over reading full files. Return structured answers in the requested format.
+    max_iterations: 20
+    summarize_tool_response: false
+
+---
+kind: benchmark
+spec:
+  description: >
+    Code intelligence tasks using jcodemunch-mcp — an MCP server that provides
+    symbol search, file outlines, cross-repo dependency mapping, blast radius
+    analysis, and ranked context retrieval with >99% token reduction vs. naive
+    file reading. Tasks target the jgravelle/jcodemunch-mcp repository itself.
+  agent: ReAct-agent
+  tasks:
+    - mcpuniverse/code_intelligence/jcodemunch_task_0001.json
+    - mcpuniverse/code_intelligence/jcodemunch_task_0002.json
+    - mcpuniverse/code_intelligence/jcodemunch_task_0003.json
+    - mcpuniverse/code_intelligence/jcodemunch_task_0004.json
+    - mcpuniverse/code_intelligence/jcodemunch_task_0005.json
+    - mcpuniverse/code_intelligence/jcodemunch_task_0006.json
+    - mcpuniverse/code_intelligence/jcodemunch_task_0007.json
+    - mcpuniverse/code_intelligence/jcodemunch_task_0008.json
+    - mcpuniverse/code_intelligence/jcodemunch_task_0009.json
+    - mcpuniverse/code_intelligence/jcodemunch_task_0010.json

--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0001.json
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0001.json
@@ -1,0 +1,23 @@
+{
+    "category": "code-intelligence",
+    "question": "Using jcodemunch, index the GitHub repository jgravelle/jcodemunch-mcp. Then search for all symbols named 'parse_file'. Report the file path where this function is defined.",
+    "output_format": {
+        "file_path": "[path to the file containing parse_file]"
+    },
+    "use_specified_server": true,
+    "mcp_servers": [
+        {
+            "name": "jcodemunch"
+        }
+    ],
+    "evaluators": [
+        {
+            "func": "raw",
+            "op": "jcodemunch.llm_as_a_judge",
+            "op_args": {
+                "question": "In the jgravelle/jcodemunch-mcp repository, what file contains the function named 'parse_file'?",
+                "correct_answer": "src/jcodemunch_mcp/parser/extractor.py"
+            }
+        }
+    ]
+}

--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0002.json
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0002.json
@@ -1,0 +1,23 @@
+{
+    "category": "code-intelligence",
+    "question": "Using jcodemunch, index the GitHub repository jgravelle/jcodemunch-mcp. Then get the file outline for 'src/jcodemunch_mcp/storage/sqlite_store.py'. Report the name of the main class defined in that file.",
+    "output_format": {
+        "class_name": "[name of the main class]"
+    },
+    "use_specified_server": true,
+    "mcp_servers": [
+        {
+            "name": "jcodemunch"
+        }
+    ],
+    "evaluators": [
+        {
+            "func": "raw",
+            "op": "jcodemunch.llm_as_a_judge",
+            "op_args": {
+                "question": "What is the name of the main class defined in src/jcodemunch_mcp/storage/sqlite_store.py in the jgravelle/jcodemunch-mcp repository?",
+                "correct_answer": "CodeIndex"
+            }
+        }
+    ]
+}

--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0003.json
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0003.json
@@ -1,0 +1,23 @@
+{
+    "category": "code-intelligence",
+    "question": "Using jcodemunch, index the GitHub repository jgravelle/jcodemunch-mcp. Then get the high-level repository outline. Report how many top-level directories are listed under the 'src' directory.",
+    "output_format": {
+        "directory_count": "[number of top-level directories under src]"
+    },
+    "use_specified_server": true,
+    "mcp_servers": [
+        {
+            "name": "jcodemunch"
+        }
+    ],
+    "evaluators": [
+        {
+            "func": "raw",
+            "op": "jcodemunch.llm_as_a_judge",
+            "op_args": {
+                "question": "In jgravelle/jcodemunch-mcp, how many top-level directories are there under the src/jcodemunch_mcp directory? Count only directories, not files.",
+                "correct_answer": "5 directories: parser, storage, summarizer, tools, and the root jcodemunch_mcp package itself contains server.py, security.py, config.py"
+            }
+        }
+    ]
+}

--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0004.json
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0004.json
@@ -1,0 +1,23 @@
+{
+    "category": "code-intelligence",
+    "question": "Using jcodemunch, index the GitHub repository jgravelle/jcodemunch-mcp. Then use find_references to find all files that reference the identifier 'CodeIndex'. Report how many distinct files reference it (count only .py files).",
+    "output_format": {
+        "file_count": "[number of Python files referencing CodeIndex]"
+    },
+    "use_specified_server": true,
+    "mcp_servers": [
+        {
+            "name": "jcodemunch"
+        }
+    ],
+    "evaluators": [
+        {
+            "func": "raw",
+            "op": "jcodemunch.llm_as_a_judge",
+            "op_args": {
+                "question": "In jgravelle/jcodemunch-mcp, does the identifier 'CodeIndex' appear in more than one Python file?",
+                "correct_answer": "Yes, CodeIndex is referenced in multiple Python files including sqlite_store.py where it is defined, server.py, and various tool files and tests."
+            }
+        }
+    ]
+}

--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0005.json
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0005.json
@@ -1,0 +1,24 @@
+{
+    "category": "code-intelligence",
+    "question": "Using jcodemunch, index the GitHub repository jgravelle/jcodemunch-mcp. Then use get_dependency_graph to get the imports for the file 'src/jcodemunch_mcp/server.py'. Report whether 'security' or 'config' modules are among its direct imports.",
+    "output_format": {
+        "imports_security": "[yes or no]",
+        "imports_config": "[yes or no]"
+    },
+    "use_specified_server": true,
+    "mcp_servers": [
+        {
+            "name": "jcodemunch"
+        }
+    ],
+    "evaluators": [
+        {
+            "func": "raw",
+            "op": "jcodemunch.llm_as_a_judge",
+            "op_args": {
+                "question": "Does src/jcodemunch_mcp/server.py in jgravelle/jcodemunch-mcp import from both the security module and the config module?",
+                "correct_answer": "Yes, server.py imports from both security.py (for path validation) and config.py (for configuration management)."
+            }
+        }
+    ]
+}

--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0006.json
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0006.json
@@ -1,0 +1,23 @@
+{
+    "category": "code-intelligence",
+    "question": "Using jcodemunch, index the GitHub repository jgravelle/jcodemunch-mcp. Then use get_ranked_context to retrieve the most relevant code for the query 'how does AI summarization work'. Report the name of at least one file or function that appears in the ranked results.",
+    "output_format": {
+        "relevant_file_or_function": "[name of a file or function from the ranked context]"
+    },
+    "use_specified_server": true,
+    "mcp_servers": [
+        {
+            "name": "jcodemunch"
+        }
+    ],
+    "evaluators": [
+        {
+            "func": "raw",
+            "op": "jcodemunch.llm_as_a_judge",
+            "op_args": {
+                "question": "When querying jgravelle/jcodemunch-mcp for 'how does AI summarization work', does the ranked context include anything from the summarizer directory or batch_summarize.py?",
+                "correct_answer": "Yes, the ranked context should surface batch_summarize.py or files in the summarizer/ directory, as that is where AI summarization is implemented."
+            }
+        }
+    ]
+}

--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0007.json
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0007.json
@@ -1,0 +1,24 @@
+{
+    "category": "code-intelligence",
+    "question": "Using jcodemunch, index the GitHub repository jgravelle/jcodemunch-mcp. Then use get_symbol_source to retrieve the source code of the symbol 'validate_path' from 'src/jcodemunch_mcp/security.py'. Report whether the function raises an exception for paths outside allowed directories.",
+    "output_format": {
+        "raises_on_unsafe_path": "[yes or no]",
+        "exception_type": "[name of the exception raised, or 'none']"
+    },
+    "use_specified_server": true,
+    "mcp_servers": [
+        {
+            "name": "jcodemunch"
+        }
+    ],
+    "evaluators": [
+        {
+            "func": "raw",
+            "op": "jcodemunch.llm_as_a_judge",
+            "op_args": {
+                "question": "Does the validate_path function in src/jcodemunch_mcp/security.py raise an exception when a path is outside allowed directories?",
+                "correct_answer": "Yes, validate_path raises an exception (ValueError or a custom security error) when the path is outside trusted/allowed directories."
+            }
+        }
+    ]
+}

--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0008.json
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0008.json
@@ -1,0 +1,23 @@
+{
+    "category": "code-intelligence",
+    "question": "Using jcodemunch, index the GitHub repository jgravelle/jcodemunch-mcp. Then use find_importers to find all files that import from 'src/jcodemunch_mcp/storage/sqlite_store.py'. Report the names of at least two files that import from it.",
+    "output_format": {
+        "importing_files": "[comma-separated list of at least two files that import from sqlite_store.py]"
+    },
+    "use_specified_server": true,
+    "mcp_servers": [
+        {
+            "name": "jcodemunch"
+        }
+    ],
+    "evaluators": [
+        {
+            "func": "raw",
+            "op": "jcodemunch.llm_as_a_judge",
+            "op_args": {
+                "question": "In jgravelle/jcodemunch-mcp, do multiple files import from sqlite_store.py?",
+                "correct_answer": "Yes, multiple files import CodeIndex or other symbols from sqlite_store.py, including server.py and various tool files under the tools/ directory."
+            }
+        }
+    ]
+}

--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0009.json
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0009.json
@@ -1,0 +1,24 @@
+{
+    "category": "code-intelligence",
+    "question": "Using jcodemunch, index the GitHub repository jgravelle/jcodemunch-mcp. Then use get_blast_radius to determine what files would be impacted if 'src/jcodemunch_mcp/config.py' were changed. Report whether server.py appears in the blast radius.",
+    "output_format": {
+        "server_py_in_blast_radius": "[yes or no]",
+        "total_impacted_files": "[approximate count of impacted files]"
+    },
+    "use_specified_server": true,
+    "mcp_servers": [
+        {
+            "name": "jcodemunch"
+        }
+    ],
+    "evaluators": [
+        {
+            "func": "raw",
+            "op": "jcodemunch.llm_as_a_judge",
+            "op_args": {
+                "question": "If config.py changes in jgravelle/jcodemunch-mcp, does server.py appear in the blast radius (i.e., would server.py be impacted)?",
+                "correct_answer": "Yes, server.py imports from config.py and would be in the blast radius of any config.py change."
+            }
+        }
+    ]
+}

--- a/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0010.json
+++ b/mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/jcodemunch_task_0010.json
@@ -1,0 +1,24 @@
+{
+    "category": "code-intelligence",
+    "question": "Using jcodemunch, index the GitHub repository jgravelle/jcodemunch-mcp. Then use search_symbols to find all symbols of type 'class' in the repository. Report the total number of classes found and name at least three of them.",
+    "output_format": {
+        "total_classes": "[number of classes found]",
+        "sample_classes": "[comma-separated list of at least three class names]"
+    },
+    "use_specified_server": true,
+    "mcp_servers": [
+        {
+            "name": "jcodemunch"
+        }
+    ],
+    "evaluators": [
+        {
+            "func": "raw",
+            "op": "jcodemunch.llm_as_a_judge",
+            "op_args": {
+                "question": "Does jgravelle/jcodemunch-mcp contain multiple Python classes, including CodeIndex?",
+                "correct_answer": "Yes, the repository contains multiple classes. CodeIndex is one of them (in sqlite_store.py). Others include configuration classes, summarizer classes, and language specification classes like LanguageSpec."
+            }
+        }
+    ]
+}

--- a/mcpuniverse/evaluator/__init__.py
+++ b/mcpuniverse/evaluator/__init__.py
@@ -14,6 +14,7 @@ from .google_search.functions import *
 from .deepresearch.functions import *
 from .notion.functions import *
 from .weather.functions import *
+from .jcodemunch.functions import *
 # from .mcpmark.functions import *  # Temporarily disabled due to psycopg2 dependency
 from .mcpmark.github_functions import *
 from .mcpmark.notion_functions import *

--- a/mcpuniverse/evaluator/jcodemunch/functions.py
+++ b/mcpuniverse/evaluator/jcodemunch/functions.py
@@ -1,0 +1,121 @@
+"""
+Evaluation functions for jcodemunch-mcp code intelligence tasks.
+
+jcodemunch-mcp is a code intelligence MCP server that provides symbol search,
+file outlines, cross-repo dependency mapping, and targeted code retrieval with
+dramatically reduced token usage compared to naive file reading.
+"""
+# pylint: disable=broad-exception-caught,unused-argument
+from typing import Any
+from openai import OpenAI
+from dotenv import load_dotenv
+from mcpuniverse.evaluator.functions import compare_func
+from mcpuniverse.common.context import Context
+
+load_dotenv()
+
+
+##################################################################################
+# Utils
+##################################################################################
+
+def jcodemunch__get_judge_prompt(question: str, response: str, correct_answer: str) -> str:
+    return f"""
+Judge whether the following [response] to [question] is correct or not based on the [correct_answer].
+
+[question]: {question}
+
+[response]: {response}
+
+Your judgement must be in the format and criteria specified below:
+
+extracted_final_answer: The final exact answer extracted from the [response]. Put 'None' if there is no extractable answer.
+
+[correct_answer]: {correct_answer}
+
+reasoning: Explain why the extracted_final_answer is correct or incorrect based on [correct_answer]. Focus only on whether the answers match meaningfully — ignore formatting differences, extra context, or minor phrasing variations.
+
+correct: Answer 'yes' if extracted_final_answer meaningfully matches [correct_answer]. Answer 'no' otherwise.
+"""
+
+
+def jcodemunch__call_gpt(
+        prompt: str,
+        model: str = "gpt-4.1",
+        temperature: float = 0.0,
+        **kwargs
+) -> str:
+    context: Context = kwargs.get("context", Context())
+    client = OpenAI(api_key=context.get_env("OPENAI_API_KEY"))
+    attempt = 5
+    while attempt > 0:
+        try:
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": prompt}
+                ],
+                temperature=temperature
+            )
+            return response.choices[0].message.content
+        except Exception as e:
+            attempt -= 1
+            print(f"Error: {e}")
+    return None
+
+
+##################################################################################
+# Comparison functions
+##################################################################################
+
+@compare_func(name="jcodemunch.llm_as_a_judge")
+async def jcodemunch__llm_as_a_judge(llm_response: Any, *args, **kwargs) -> (bool, str):
+    """
+    LLM-as-a-judge evaluator for jcodemunch code intelligence tasks.
+    Checks whether the agent's response correctly answers the question
+    given a known-correct answer about the indexed codebase.
+    """
+    _, values = args
+    question = values["question"]
+    correct_answer = values["correct_answer"]
+    error_message = ""
+    for _ in range(3):
+        try:
+            response = llm_response if isinstance(llm_response, str) else llm_response.result
+            prompt = jcodemunch__get_judge_prompt(question, response, correct_answer)
+            judge_response = jcodemunch__call_gpt(prompt, **kwargs)
+            if judge_response is None:
+                return False, "LLM judge returned no response"
+            verdict = judge_response.split("correct:")[1].strip()
+            if "yes" in verdict:
+                return True, ""
+            return False, "output does not match expected answer"
+        except Exception as e:
+            error_message += str(e) + "\n"
+    return False, "ERROR: " + error_message
+
+
+@compare_func(name="jcodemunch.check_fields_present")
+async def jcodemunch__check_fields_present(llm_response: Any, *args, **kwargs) -> (bool, str):
+    """
+    Checks that the agent's JSON response contains all required fields.
+    op_args should be a list of required field names.
+    """
+    import json as json_mod
+    _, required_fields = args
+    try:
+        raw = llm_response if isinstance(llm_response, str) else llm_response.result
+        if isinstance(raw, str):
+            raw = raw.strip().strip("`").strip()
+            if raw.startswith("json"):
+                raw = raw[4:].strip()
+            data = json_mod.loads(raw)
+        else:
+            data = raw
+        missing = [f for f in required_fields if f not in data]
+        if missing:
+            return False, f"Missing required fields: {missing}"
+        return True, ""
+    except Exception as e:
+        return False, f"Could not parse response as JSON: {e}"

--- a/mcpuniverse/mcp/configs/server_list.json
+++ b/mcpuniverse/mcp/configs/server_list.json
@@ -374,5 +374,14 @@
         "-m", "mcpuniverse.mcp.servers.python_code_sandbox"
       ]
     }
+  },
+
+  "jcodemunch": {
+    "stdio": {
+      "command": "uvx",
+      "args": [
+        "jcodemunch-mcp"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

This PR adds **jcodemunch-mcp** as a new server and benchmark category to MCP-Universe, introducing a _code intelligence_ domain that isn't currently represented in the benchmark suite.

**jcodemunch-mcp** is a production MCP server (PyPI: `jcodemunch-mcp`, MCP Registry: `io.github.jgravelle/jcodemunch-mcp`) that provides:
- Symbol search, file outlines, cross-repo dependency mapping
- Blast radius analysis, ranked context retrieval, import graph traversal
- >99% token reduction vs. naive file reading (150-531x compression measured on Express, FastAPI, Gin production repos)

### Changes

| File | Purpose |
|------|---------|
| `mcpuniverse/mcp/configs/server_list.json` | Register `jcodemunch` server via `uvx jcodemunch-mcp` (stdio) |
| `mcpuniverse/evaluator/jcodemunch/functions.py` | New evaluator: `jcodemunch.llm_as_a_judge` + `jcodemunch.check_fields_present` |
| `mcpuniverse/evaluator/__init__.py` | Import jcodemunch evaluator |
| `mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence.yaml` | Benchmark config (ReAct agent, gpt-4.1, 10 tasks) |
| `mcpuniverse/benchmark/configs/mcpuniverse/code_intelligence/` | 10 task JSON files |

### Tasks covered

The 10 tasks exercise distinct jcodemunch tools against a stable public repo (`jgravelle/jcodemunch-mcp`):

1. `search_symbols` -- locate a named function across the repo
2. `get_file_outline` -- list symbols in a specific file
3. `get_repo_outline` -- high-level directory structure
4. `find_references` -- all files referencing a given identifier
5. `get_dependency_graph` -- direct imports of a file
6. `get_ranked_context` -- BM25+PageRank context retrieval for a natural-language query
7. `get_symbol_source` -- retrieve full implementation of a named symbol
8. `find_importers` -- reverse import graph (what imports a given file)
9. `get_blast_radius` -- transitive impact of changing a file
10. `search_symbols` (by type) -- enumerate all classes in the repo

All evaluators use `jcodemunch.llm_as_a_judge` with known-correct ground-truth answers derived from the target repository.

## Why this matters

Code intelligence is one of the highest-value MCP use cases and is absent from the current benchmark domains (web search, 3D design, browser automation, financial analysis, location navigation, repository management). Adding it creates a reproducible, third-party-validated baseline for this category.

## Test plan

- [ ] `uvx jcodemunch-mcp` starts without error (requires Python >= 3.10)
- [ ] `jgravelle/jcodemunch-mcp` is a public repo accessible without auth
- [ ] All 10 task JSON files parse correctly against the benchmark schema
- [ ] Evaluator module imports cleanly (`from mcpuniverse.evaluator.jcodemunch.functions import *`)
- [ ] At least one end-to-end task run completes with a meaningful pass/fail verdict

## Notes

- No additional env vars required (jcodemunch-mcp works without API keys; AI summarization is opt-in)
- The evaluator follows the same pattern as `google_search.llm_as_a_judge` and requires `OPENAI_API_KEY` in the environment for judging
- Tasks intentionally target a small, stable, well-understood repo to minimize flakiness

Contributor has read and agrees to sign the Salesforce CLA.

---
_jcodemunch-mcp: https://github.com/jgravelle/jcodemunch-mcp_